### PR TITLE
CassandraSession.on_update bug

### DIFF
--- a/cassandra_flask_sessions/__init__.py
+++ b/cassandra_flask_sessions/__init__.py
@@ -11,7 +11,7 @@ class CassandraSession(CallbackDict, SessionMixin):
         def on_update(self):
             self.modified = True
 
-        CallbackDict.__init__(self, initial)
+        CallbackDict.__init__(self, initial, on_update)
         self.sid = sid
         self.modified = False
 


### PR DESCRIPTION
`def on_update` doesn't work. As result [response.delete_cookie](https://github.com/mikicaivosevic/flask-cassandra-sessions/blob/master/cassandra_flask_sessions/__init__.py#L52) is never called.